### PR TITLE
Sensor/icm42670 s attr set apis

### DIFF
--- a/drivers/sensor/icm42670S/icm42670S.c
+++ b/drivers/sensor/icm42670S/icm42670S.c
@@ -368,14 +368,11 @@ static int icm42670S_attr_set(const struct device *dev,
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_XYZ:
 		if (attr == SENSOR_ATTR_CONFIGURATION) {
-			if (val->val1 == 0) {
-				LOG_DBG("Power off accel");
+			if (val->val1 == ICM42670S_POWER_OFF) {
 				err |= inv_imu_disable_accel(&drv_data->driver);
-			} else if (val->val1 == 1) {
-				LOG_DBG("Set accel low power mode");
+			} else if (val->val1 == ICM42670S_LOW_POWER_MODE) {
 				err |= inv_imu_enable_accel_low_power_mode(&drv_data->driver);
-			} else if (val->val1 == 2) {
-				LOG_DBG("Set accel low noise mode");
+			} else if (val->val1 == ICM42670S_LOW_NOISE_MODE) {
 				err |= inv_imu_enable_accel_low_noise_mode(&drv_data->driver);
 			} else {
 				LOG_ERR("Not supported ATTR value");
@@ -387,7 +384,6 @@ static int icm42670S_attr_set(const struct device *dev,
 				LOG_ERR("Incorrect sampling value");
 				return -EINVAL;
 			} else {
-				LOG_DBG("Set accel frequency to: %d Hz", val->val1);
 				err |= inv_imu_set_accel_frequency(&drv_data->driver, 
 						convert_freq_to_bitfield(val->val1));	
 			}
@@ -428,11 +424,9 @@ static int icm42670S_attr_set(const struct device *dev,
 		
 	case SENSOR_CHAN_GYRO_XYZ:
 		if (attr == SENSOR_ATTR_CONFIGURATION) {
-			if (val->val1 == 0) {
-				LOG_DBG("Power off gyro");
+			if (val->val1 == ICM42670S_POWER_OFF) {
 				err |= inv_imu_disable_gyro(&drv_data->driver);
-			} else if (val->val1 == 2) {
-				LOG_DBG("Set gyro low noise mode");
+			} else if (val->val1 == ICM42670S_LOW_NOISE_MODE) {
 				err |= inv_imu_enable_gyro_low_noise_mode(&drv_data->driver);
 			} else {
 				LOG_ERR("Not supported ATTR value");
@@ -444,7 +438,6 @@ static int icm42670S_attr_set(const struct device *dev,
 				LOG_ERR("Incorrect sampling value");
 				return -EINVAL;
 			} else {
-				LOG_DBG("Set gyro frequency to: %d Hz", val->val1);
 				err |= inv_imu_set_gyro_frequency(&drv_data->driver, 
 						convert_freq_to_bitfield(val->val1));
 			}

--- a/drivers/sensor/icm42670S/icm42670S.h
+++ b/drivers/sensor/icm42670S/icm42670S.h
@@ -72,11 +72,9 @@ struct icm42670S_data {
 	const struct sensor_trigger *data_ready_trigger;
 	sensor_trigger_handler_t data_ready_handler;
 
-#ifdef CONFIG_ICM42670S_TRIGGER
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_ICM42670S_THREAD_STACK_SIZE);
 	struct k_thread thread;
 	struct k_sem gpio_sem;
-#endif
 };
 
 struct icm42670S_config {

--- a/drivers/sensor/icm42670S/icm42670S.h
+++ b/drivers/sensor/icm42670S/icm42670S.h
@@ -62,24 +62,15 @@ struct icm42670S_data {
 	int32_t accel[3];
 	int32_t gyro[3];
 	int32_t temperature;
-	
-	bool accel_en;
-	bool gyro_en;
-	bool tap_en;
 
-	bool sensor_started;
+	uint32_t accel_odr_us;
+	uint32_t gyro_odr_us;
 	
 	const struct device *dev;
 	struct gpio_callback gpio_cb;
 
 	const struct sensor_trigger *data_ready_trigger;
 	sensor_trigger_handler_t data_ready_handler;
-
-	const struct sensor_trigger *tap_trigger;
-	sensor_trigger_handler_t tap_handler;
-
-	const struct sensor_trigger *double_tap_trigger;
-	sensor_trigger_handler_t double_tap_handler;
 
 #ifdef CONFIG_ICM42670S_TRIGGER
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_ICM42670S_THREAD_STACK_SIZE);
@@ -91,11 +82,7 @@ struct icm42670S_data {
 struct icm42670S_config {
 	union icm42670S_bus bus;
 	const struct icm42670S_bus_io *bus_io;
-	struct gpio_dt_spec gpio_int;
-	uint16_t accel_hz;
-	uint16_t gyro_hz;
-	uint16_t accel_fs;
-	uint16_t gyro_fs;	
+	struct gpio_dt_spec gpio_int;	
 };
 
 int icm42670S_trigger_set(const struct device *dev,

--- a/drivers/sensor/icm42670S/icm42670S.h
+++ b/drivers/sensor/icm42670S/icm42670S.h
@@ -63,8 +63,8 @@ struct icm42670S_data {
 	int32_t gyro[3];
 	int32_t temperature;
 
-	uint32_t accel_odr_us;
-	uint32_t gyro_odr_us;
+	uint8_t accel_fs;
+	uint16_t gyro_fs;
 	
 	const struct device *dev;
 	struct gpio_callback gpio_cb;

--- a/include/zephyr/drivers/sensor/icm42670S.h
+++ b/include/zephyr/drivers/sensor/icm42670S.h
@@ -9,9 +9,22 @@
 
 #include <zephyr/drivers/sensor.h>
 
+
 /**
  * @file
  * @brief Extended public API for ICM42670S 6-axis MEMS sensor
+ *
+ * Some capabilities and operational requirements for this sensor
+ * cannot be expressed within the sensor driver abstraction.
+ */
+
+/** ICM42670S power mode */
+#define ICM42670S_POWER_OFF         (0)
+#define ICM42670S_LOW_POWER_MODE    (1)
+#define ICM42670S_LOW_NOISE_MODE    (2)
+
+/**
+ * @brief Extended sensor attributes for ICM42670S 6-axis MEMS sensor
  *
  * This exposes attributes for the ICM42670S which can be used for
  * setting the signal path filtering parameters.
@@ -19,7 +32,6 @@
  * The signal path starts with ADCs for the gyroscope and accelerometer. 
  * Low-Noise Mode and Low-Power Mode options are available for the 
  * accelerometer. Only Low-Noise Mode is available for gyroscope.
- *
  * In Low-Noise Mode, the ADC output is sent through an Anti-Alias Filter
  * (AAF). The AAF is a filter with fixed coefficients (not user configurable),
  * also the AAF cannot be bypassed. The AAF is followed by a 1st Order Low Pass 
@@ -30,8 +42,8 @@
  * Mode is subject to ODR selection, with user selectable ODR.
  */
 enum sensor_attribute_icm42670S {
-	/** BW filtering */
-	 
+	/** BW filtering */	 
+	
 	/** Low-pass filter configuration */
 	SENSOR_ATTR_BW_FILTER_LPF = SENSOR_ATTR_PRIV_START,
 	/** Averaging configuration */

--- a/include/zephyr/drivers/sensor/icm42670S.h
+++ b/include/zephyr/drivers/sensor/icm42670S.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 TDK Invensense
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_ICM42670S_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_ICM42670S_H_
+
+#include <zephyr/drivers/sensor.h>
+
+/**
+ * @file
+ * @brief Extended public API for ICM42670S 6-axis MEMS sensor
+ *
+ * This exposes attributes for the ICM42670S which can be used for
+ * setting the signal path filtering parameters.
+ *
+ * The signal path starts with ADCs for the gyroscope and accelerometer. 
+ * Low-Noise Mode and Low-Power Mode options are available for the 
+ * accelerometer. Only Low-Noise Mode is available for gyroscope.
+ *
+ * In Low-Noise Mode, the ADC output is sent through an Anti-Alias Filter
+ * (AAF). The AAF is a filter with fixed coefficients (not user configurable),
+ * also the AAF cannot be bypassed. The AAF is followed by a 1st Order Low Pass 
+ * Filter (LPF) with user selectable filter bandwidth options. 
+ * In Low-Power Mode, the accelerometer ADC output is sent through an Average
+ * filter, with user configurable average filter setting.
+ * The output of 1st Order LPF in Low-Noise Mode, or Average filter in Low-Power
+ * Mode is subject to ODR selection, with user selectable ODR.
+ */
+enum sensor_attribute_icm42670S {
+	/** BW filtering */
+	 
+	/** Low-pass filter configuration */
+	SENSOR_ATTR_BW_FILTER_LPF = SENSOR_ATTR_PRIV_START,
+	/** Averaging configuration */
+	SENSOR_ATTR_AVERAGING,
+};
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_ICM42670S_H_ */

--- a/samples/sensor/icm42670S/src/main.c
+++ b/samples/sensor/icm42670S/src/main.c
@@ -12,7 +12,6 @@
 #include <stdio.h>
 
 static struct sensor_trigger data_trigger;
-static uint32_t now;
 
 /* Flag set from IMU device irq handler */
 static volatile int irq_from_device = 0;
@@ -46,6 +45,7 @@ static const struct device *get_icm42670S_device(void)
 static const char *now_str(void)
 {
 	static char buf[16]; /* ...HH:MM:SS.MMM */
+	uint32_t now = k_uptime_get_32();
 	unsigned int ms = now % MSEC_PER_SEC;
 	unsigned int s;
 	unsigned int min;
@@ -70,7 +70,6 @@ static int process_icm42670S(const struct device *dev)
 	if (rc != 0) { 
 		printf("sample fetch failed: %d\n", rc);
 	} else {
-		now = k_uptime_get_32();
 		irq_from_device = 1;
 	}
 
@@ -140,7 +139,7 @@ int main(void)
 			&sampling_freq);
 	
 	/* Setting mode 0:Off, 1:Low power (only Accel) 2:Low noise */
-	mode.val1 = 2;	
+	mode.val1 = ICM42670S_LOW_NOISE_MODE;	
 	sensor_attr_set(dev, SENSOR_CHAN_ACCEL_XYZ,
 			SENSOR_ATTR_CONFIGURATION,
 			&mode);

--- a/samples/sensor/icm42670S/src/main.c
+++ b/samples/sensor/icm42670S/src/main.c
@@ -94,6 +94,7 @@ int main(void)
 	struct sensor_value accel[3];
 	struct sensor_value gyro[3];
 	struct sensor_value temperature;
+	struct sensor_value sampling_freq, mode;
 
 	if (dev == NULL) {
 		return 0;
@@ -104,6 +105,26 @@ int main(void)
 		.chan = SENSOR_CHAN_ALL,
 	};
 
+	/* Setting sampling frequency */
+	sampling_freq.val1 = 100;       /* Hz */
+	sampling_freq.val2 = 0;
+	
+	sensor_attr_set(dev, SENSOR_CHAN_ACCEL_XYZ,
+			SENSOR_ATTR_SAMPLING_FREQUENCY,
+			&sampling_freq);
+	sensor_attr_set(dev, SENSOR_CHAN_GYRO_XYZ,
+			SENSOR_ATTR_SAMPLING_FREQUENCY,
+			&sampling_freq);
+	
+	/* Setting mode 0:Off, 1:Low power (only Accel) 2:Low noise */
+	mode.val1 = 2;	
+	sensor_attr_set(dev, SENSOR_CHAN_ACCEL_XYZ,
+			SENSOR_ATTR_CONFIGURATION,
+			&mode);
+	sensor_attr_set(dev, SENSOR_CHAN_GYRO_XYZ,
+			SENSOR_ATTR_CONFIGURATION,
+			&mode);
+			
 	if (sensor_trigger_set(dev, &data_trigger,
 			       handle_icm42670S_drdy) < 0) {
 		printf("Cannot configure data trigger!!!\n");
@@ -136,4 +157,5 @@ int main(void)
 			irq_from_device = 0;
 		}
 	}
+	return 0;
 }

--- a/samples/sensor/icm42670S/src/main.c
+++ b/samples/sensor/icm42670S/src/main.c
@@ -94,7 +94,7 @@ int main(void)
 	struct sensor_value accel[3];
 	struct sensor_value gyro[3];
 	struct sensor_value temperature;
-	struct sensor_value sampling_freq, mode;
+	struct sensor_value full_scale, sampling_freq, mode;
 
 	if (dev == NULL) {
 		return 0;
@@ -105,10 +105,21 @@ int main(void)
 		.chan = SENSOR_CHAN_ALL,
 	};
 
+	/* Setting full scale */
+	full_scale.val1 = 2; /* G */
+	full_scale.val2 = 0;
+	sensor_attr_set(dev, SENSOR_CHAN_ACCEL_XYZ,
+				SENSOR_ATTR_FULL_SCALE,
+				&full_scale);
+	full_scale.val1 = 1000; /* dps */
+	full_scale.val2 = 0;
+	sensor_attr_set(dev, SENSOR_CHAN_GYRO_XYZ,
+				SENSOR_ATTR_FULL_SCALE,
+				&full_scale);
+	
 	/* Setting sampling frequency */
 	sampling_freq.val1 = 100;       /* Hz */
 	sampling_freq.val2 = 0;
-	
 	sensor_attr_set(dev, SENSOR_CHAN_ACCEL_XYZ,
 			SENSOR_ATTR_SAMPLING_FREQUENCY,
 			&sampling_freq);

--- a/samples/sensor/icm42670S/src/main.c
+++ b/samples/sensor/icm42670S/src/main.c
@@ -8,6 +8,7 @@
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor/icm42670S.h>
 #include <stdio.h>
 
 static struct sensor_trigger data_trigger;
@@ -94,6 +95,7 @@ int main(void)
 	struct sensor_value accel[3];
 	struct sensor_value gyro[3];
 	struct sensor_value temperature;
+	struct sensor_value bw_filter;
 	struct sensor_value full_scale, sampling_freq, mode;
 
 	if (dev == NULL) {
@@ -105,6 +107,16 @@ int main(void)
 		.chan = SENSOR_CHAN_ALL,
 	};
 
+	/* Setting LN bandwith filtering options */
+	bw_filter.val1 = 180; /* Hz */
+	bw_filter.val2 = 0;
+	sensor_attr_set(dev, SENSOR_CHAN_ACCEL_XYZ,
+				SENSOR_ATTR_BW_FILTER_LPF,
+				&bw_filter);
+	sensor_attr_set(dev, SENSOR_CHAN_GYRO_XYZ,
+				SENSOR_ATTR_BW_FILTER_LPF,
+				&bw_filter);
+	
 	/* Setting full scale */
 	full_scale.val1 = 2; /* G */
 	full_scale.val2 = 0;


### PR DESCRIPTION
Add attribute set APIs;

- sampling mode (OFF/LN/LP),
- full-scale, 
- LN filtering and LP averaging, 
- sampling frequency 

Add header to define new specific attributes for icm42670S (include/zephyr/drivers/sensor/icm42670S.h)
Clean-up