### PR TITLE
Support SPI communication

### DIFF
--- a/drivers/sensor/icm42670S/icm42670S.c
+++ b/drivers/sensor/icm42670S/icm42670S.c
@@ -766,7 +766,12 @@ static int icm42670S_chip_init(const struct device *dev)
 	data->serif.write_reg = inv_io_hal_write_reg;
 	data->serif.max_read = 1024 * 32;
 	data->serif.max_write = 1024 * 32;
+#if ICM42670S_BUS_SPI
+	data->serif.serif_type = UI_SPI4;
+#endif
+#if ICM42670S_BUS_I2C
 	data->serif.serif_type = UI_I2C;
+#endif
 	err = inv_imu_init(&data->driver, &data->serif, NULL);
 	if (err < 0) {
 		LOG_DBG("Init failed: %d", err);

--- a/drivers/sensor/icm42670S/icm42670S.c
+++ b/drivers/sensor/icm42670S/icm42670S.c
@@ -780,12 +780,12 @@ static int icm42670S_chip_init(const struct device *dev)
 
 	err = inv_imu_get_who_am_i(&data->driver, &data->chip_id);
 	if (err < 0) {
-		LOG_DBG("ID read failed: %d", err);
+		LOG_ERR("ID read failed: %d", err);
 		return err;
 	}
 
 	if (data->chip_id != INV_IMU_WHOAMI) {
-		LOG_DBG("bad chip id 0x%x", data->chip_id);
+		LOG_ERR("bad chip id 0x%x", data->chip_id);
 		return -ENOTSUP;
 	}
 

--- a/drivers/sensor/icm42670S/icm42670S_spi.c
+++ b/drivers/sensor/icm42670S/icm42670S_spi.c
@@ -23,7 +23,7 @@ static int icm42670S_bus_check_spi(const union icm42670S_bus *bus)
 static int icm42670S_reg_read_spi(const union icm42670S_bus *bus, uint8_t start, uint8_t *buf,
 				  uint32_t size)
 {
-	uint8_t cmd[] = {(start | 0x80), 0};
+	uint8_t cmd[] = {(start | 0x80)};
 	const struct spi_buf tx_buf = {.buf = cmd, .len = sizeof(cmd)};
 	const struct spi_buf_set tx = {.buffers = &tx_buf, .count = 1};
 	struct spi_buf rx_buf[2];
@@ -47,16 +47,15 @@ static int icm42670S_reg_read_spi(const union icm42670S_bus *bus, uint8_t start,
 static int icm42670S_reg_write_spi(const union icm42670S_bus *bus, uint8_t reg, uint8_t *buf,
 				   uint32_t size)
 {
-	uint8_t cmd[] = {reg & 0x7F, *buf};
-	const struct spi_buf tx_buf = {.buf = cmd, .len = sizeof(cmd)};
-	const struct spi_buf_set tx = {.buffers = &tx_buf, .count = size};
-	int ret;
+	uint8_t cmd[] = {reg & 0x7F};
+	const struct spi_buf tx_buf[2] = {{.buf = cmd, .len = sizeof(cmd)},{.buf = buf, .len = size}};
+	const struct spi_buf_set tx = {.buffers = tx_buf, .count = 2};
 
-	ret = spi_write_dt(&bus->spi, &tx);
+	int ret = spi_write_dt(&bus->spi, &tx);
 	if (ret) {
 		LOG_ERR("spi_write FAIL %d\n", ret);
 		return ret;
-	}
+	}	
 	return 0;
 }
 

--- a/drivers/sensor/icm42670S/icm42670S_spi.c
+++ b/drivers/sensor/icm42670S/icm42670S_spi.c
@@ -21,46 +21,40 @@ static int icm42670S_bus_check_spi(const union icm42670S_bus *bus)
 }
 
 static int icm42670S_reg_read_spi(const union icm42670S_bus *bus, uint8_t start, uint8_t *buf,
-				  int size)
+				  uint32_t size)
 {
-	uint8_t addr;
-	const struct spi_buf tx_buf = {.buf = &addr, .len = 1};
+	uint8_t cmd[] = {(start | 0x80), 0};
+	const struct spi_buf tx_buf = {.buf = cmd, .len = sizeof(cmd)};
 	const struct spi_buf_set tx = {.buffers = &tx_buf, .count = 1};
 	struct spi_buf rx_buf[2];
 	const struct spi_buf_set rx = {.buffers = rx_buf, .count = ARRAY_SIZE(rx_buf)};
-	int i;
+	int ret;
 
 	rx_buf[0].buf = NULL;
 	rx_buf[0].len = 1;
 
-	rx_buf[1].len = 1;
+	rx_buf[1].len = size;
+	rx_buf[1].buf = buf;
 
-	for (i = 0; i < size; i++) {
-		int ret;
-
-		addr = (start + i) | 0x80;
-		rx_buf[1].buf = &buf[i];
-
-		ret = spi_transceive_dt(&bus->spi, &tx, &rx);
-		if (ret) {
-			LOG_DBG("spi_transceive FAIL %d\n", ret);
-			return ret;
-		}
+	ret = spi_transceive_dt(&bus->spi, &tx, &rx);
+	if (ret) {
+		LOG_ERR("spi_transceive FAIL %d\n", ret);
+		return ret;
 	}
-
 	return 0;
 }
 
-static int icm42670S_reg_write_spi(const union icm42670S_bus *bus, uint8_t reg, uint8_t val)
+static int icm42670S_reg_write_spi(const union icm42670S_bus *bus, uint8_t reg, uint8_t *buf,
+				   uint32_t size)
 {
-	uint8_t cmd[] = {reg & 0x7F, val};
+	uint8_t cmd[] = {reg & 0x7F, *buf};
 	const struct spi_buf tx_buf = {.buf = cmd, .len = sizeof(cmd)};
-	const struct spi_buf_set tx = {.buffers = &tx_buf, .count = 1};
+	const struct spi_buf_set tx = {.buffers = &tx_buf, .count = size};
 	int ret;
 
 	ret = spi_write_dt(&bus->spi, &tx);
 	if (ret) {
-		LOG_DBG("spi_write FAIL %d\n", ret);
+		LOG_ERR("spi_write FAIL %d\n", ret);
 		return ret;
 	}
 	return 0;

--- a/drivers/sensor/icm42670S/imu/inv_imu_driver.c
+++ b/drivers/sensor/icm42670S/imu/inv_imu_driver.c
@@ -1483,10 +1483,6 @@ static int configure_serial_interface(inv_imu_device_t *s)
 			return INV_ERROR_BAD_ARG; /* Not supported */
 		status |= inv_imu_write_reg(s, DEVICE_CONFIG, 1, &value);
 
-		/* Workaround : Overwrite DRIVE_CONFIG3 register with 0x4 value */
-		value = 0x4;
-		status |= inv_imu_write_reg(s, DRIVE_CONFIG3, 1, &value);
-
 #if INV_IMU_REV == INV_IMU_REV_A
 		/* Device operation in shared spi bus configuration (AN-000352) */
 		status |= inv_imu_read_reg(s, INTF_CONFIG0, 1, &value);

--- a/drivers/sensor/icm42670S/imu/inv_imu_driver.c
+++ b/drivers/sensor/icm42670S/imu/inv_imu_driver.c
@@ -1483,6 +1483,10 @@ static int configure_serial_interface(inv_imu_device_t *s)
 			return INV_ERROR_BAD_ARG; /* Not supported */
 		status |= inv_imu_write_reg(s, DEVICE_CONFIG, 1, &value);
 
+		/* Workaround : Overwrite DRIVE_CONFIG3 register with 0x4 value */
+		value = 0x4;
+		status |= inv_imu_write_reg(s, DRIVE_CONFIG3, 1, &value);
+
 #if INV_IMU_REV == INV_IMU_REV_A
 		/* Device operation in shared spi bus configuration (AN-000352) */
 		status |= inv_imu_read_reg(s, INTF_CONFIG0, 1, &value);

--- a/samples/sensor/icm42670S/aml_pointing/arduino_spi.overlay
+++ b/samples/sensor/icm42670S/aml_pointing/arduino_spi.overlay
@@ -7,7 +7,7 @@
 /* Example configuration of a ICM42670S device on an Arduino SPI bus. */
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
+	cs-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>; /* D8 */
 	icm42670S@0 {
 		compatible = "invensense,icm42670S";
 		reg = <0>;

--- a/samples/sensor/icm42670S/apex/arduino_spi.overlay
+++ b/samples/sensor/icm42670S/apex/arduino_spi.overlay
@@ -7,7 +7,7 @@
 /* Example configuration of a ICM42670S device on an Arduino SPI bus. */
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
+	cs-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>; /* D8 */
 	icm42670S@0 {
 		compatible = "invensense,icm42670S";
 		reg = <0>;

--- a/samples/sensor/icm42670S/data_stream/arduino_spi.overlay
+++ b/samples/sensor/icm42670S/data_stream/arduino_spi.overlay
@@ -7,7 +7,7 @@
 /* Example configuration of a ICM42670S device on an Arduino SPI bus. */
 &arduino_spi {
 	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
+	cs-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>; /* D8 */
 	icm42670S@0 {
 		compatible = "invensense,icm42670S";
 		reg = <0>;


### PR DESCRIPTION
Add WORKAROUND in driver (0x4 in DRIVE_CONFIG3)
Fix SPI read/write with multiple bytes
Move CS pin to D8

Testing done : 
- Run the 3 examples in SPI mode with different config options.