### PR TITLE
Revert "drivers: sensor: icm45686: Change default interrupt drive"

### DIFF
--- a/drivers/sensor/tdk/icm45686/icm45686_stream.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.c
@@ -574,7 +574,7 @@ int icm45686_stream_init(const struct device *dev)
 
 		int_pin_config.int_polarity = INTX_CONFIG2_INTX_POLARITY_HIGH;
 		int_pin_config.int_mode     = INTX_CONFIG2_INTX_MODE_PULSE;
-		int_pin_config.int_drive    = INTX_CONFIG2_INTX_DRIVE_PP;
+		int_pin_config.int_drive    = INTX_CONFIG2_INTX_DRIVE_OD;
 		err = inv_imu_set_pin_config_int(&data->driver, INV_IMU_INT1, &int_pin_config);
 
 		if (err) {


### PR DESCRIPTION
Reverts InvenSenseInc/fork.zephyr-rtos#21