### PR TITLE
drivers: sensor: Update driver for TDK InvenSense ICM566xx series

### DIFF
--- a/drivers/sensor/tdk/icm566xx/CMakeLists.txt
+++ b/drivers/sensor/tdk/icm566xx/CMakeLists.txt
@@ -3,32 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
-zephyr_library_include_directories(.)
+zephyr_include_directories(.)
 zephyr_library_include_directories(${ZEPHYR_HAL_TDK_MODULE_DIR}/icm566xx)
 
 zephyr_library_sources(
   icm566xx.c
   icm566xx_bus.c
 )
-zephyr_library_sources_ifdef(CONFIG_SENSOR_ASYNC_API
-  icm566xx_decoder.c
-)
-zephyr_library_sources_ifdef(CONFIG_ICM566XX_TRIGGER
-  icm566xx_trigger.c
-)
-zephyr_library_sources_ifdef(CONFIG_TDK_APEX
-  icm566xx_apex.c
-)
-zephyr_library_sources_ifdef(CONFIG_ICM566XX_STREAM
-  icm566xx_stream.c
-)
 
-if(CONFIG_DT_HAS_INVENSENSE_ICM56622_ENABLED)
-	zephyr_compile_definitions(SENSOR_DATA_TYPE=int16_t)
-	zephyr_compile_definitions(FORMAT_SENSOR_DATA=FORMAT_16BIT_REG_DATA)
-	zephyr_compile_definitions(INV_IMU_WHOAMI=0xD3)
-elseif(CONFIG_DT_HAS_INVENSENSE_ICM56686_ENABLED)
-	zephyr_compile_definitions(SENSOR_DATA_TYPE=int32_t)
-	zephyr_compile_definitions(FORMAT_SENSOR_DATA=FORMAT_20BIT_REG_DATA)
-	zephyr_compile_definitions(INV_IMU_WHOAMI=0x08)
-endif()
+zephyr_library_sources_ifdef(CONFIG_TDK_APEX icm566xx_apex.c)
+zephyr_library_sources_ifdef(CONFIG_SENSOR_ASYNC_API icm566xx_decoder.c)
+zephyr_library_sources_ifdef(CONFIG_ICM566XX_STREAM icm566xx_stream.c)
+zephyr_library_sources_ifdef(CONFIG_ICM566XX_TRIGGER icm566xx_trigger.c)

--- a/drivers/sensor/tdk/icm566xx/Kconfig
+++ b/drivers/sensor/tdk/icm566xx/Kconfig
@@ -38,19 +38,21 @@ config ICM566XX_TRIGGER_NONE
 
 config ICM566XX_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
-	depends on GPIO
+	select GPIO
 	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM56622),int-gpios) || \
-		   $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM56686),int-gpios)
+			$(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM56686),int-gpios)
 	depends on !ICM566XX_STREAM
 	select ICM566XX_TRIGGER
+	select TDK_APEX
 
 config ICM566XX_TRIGGER_OWN_THREAD
 	bool "Use own thread"
-	depends on GPIO
+	select GPIO
 	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM56622),int-gpios) || \
-		   $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM56686),int-gpios)
+			$(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM56686),int-gpios)
 	depends on !ICM566XX_STREAM
 	select ICM566XX_TRIGGER
+	select TDK_APEX
 
 endchoice
 
@@ -77,9 +79,9 @@ config ICM566XX_THREAD_STACK_SIZE
 config ICM566XX_STREAM
 	bool "Streaming mode"
 	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM56622),int-gpios) || \
-		   $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM56686),int-gpios) || \
-		   $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM56622),i3c) || \
-		   $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM56686),i3c)
+			$(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM56686),int-gpios) || \
+			$(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM56622),i3c) || \
+			$(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM56686),i3c)
 	help
 	  Enable streaming of sensor data.
 

--- a/drivers/sensor/tdk/icm566xx/icm566xx.c
+++ b/drivers/sensor/tdk/icm566xx/icm566xx.c
@@ -30,26 +30,40 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(ICM566XX, CONFIG_SENSOR_LOG_LEVEL);
 
-static const struct device *g_icm566xx_dev = NULL;
+#ifndef SENSOR_CHANNEL_IS_ACCEL
+#define SENSOR_CHANNEL_IS_ACCEL(chan) \
+	((chan) == SENSOR_CHAN_ACCEL_XYZ || \
+	 (chan) == SENSOR_CHAN_ACCEL_X || \
+	 (chan) == SENSOR_CHAN_ACCEL_Y || \
+	 (chan) == SENSOR_CHAN_ACCEL_Z)
+#endif
 
-static inline int inv_io_hal_read_reg(uint8_t reg, uint8_t *rbuffer, uint32_t rlen)
+#ifndef SENSOR_CHANNEL_IS_GYRO
+#define SENSOR_CHANNEL_IS_GYRO(chan) \
+	((chan) == SENSOR_CHAN_GYRO_XYZ || \
+	 (chan) == SENSOR_CHAN_GYRO_X || \
+	 (chan) == SENSOR_CHAN_GYRO_Y || \
+	 (chan) == SENSOR_CHAN_GYRO_Z)
+#endif
+
+static inline int inv_io_hal_read_reg(void *context, uint8_t reg, uint8_t *rbuffer, uint32_t rlen)
 {
-	const struct device *dev = g_icm566xx_dev;
+	const struct device *dev = context;
 	struct icm566xx_data *data = dev->data;
 
 	return icm566xx_reg_read_rtio(&data->bus, reg | REG_READ_BIT, rbuffer, rlen);
 }
 
-static inline int inv_io_hal_write_reg(uint8_t reg, const uint8_t *wbuffer,
-					uint32_t wlen)
+static inline int inv_io_hal_write_reg(void *context, uint8_t reg, const uint8_t *wbuffer,
+				       uint32_t wlen)
 {
-	const struct device *dev = g_icm566xx_dev;
+	const struct device *dev = context;
 	struct icm566xx_data *data = dev->data;
 
 	return icm566xx_reg_write_rtio(&data->bus, reg, wbuffer, wlen);
 }
 
-void inv_sleep_us(uint32_t us)
+void icm566xx_inv_sleep_us(uint32_t us)
 {
 	k_usleep(us);
 }
@@ -218,6 +232,8 @@ static int icm566xx_accel_config(struct icm566xx_data *drv_data, enum sensor_att
 			}
 		} else if (val->val1 == 0) {
 			icm566xx_set_accel_mode(&drv_data->driver, PWR_MGMT0_ACCEL_MODE_OFF);
+		} else {
+			LOG_ERR("Wrong config with accel mode");
 		}
 	} else if (attr == SENSOR_ATTR_FULL_SCALE) {
 		icm566xx_set_accel_fsr(&drv_data->driver, val->val1);
@@ -250,6 +266,8 @@ static int icm566xx_gyro_config(struct icm566xx_data *drv_data, enum sensor_attr
 			}
 		} else if (val->val1 == 0) {
 			icm566xx_set_gyro_mode(&drv_data->driver, PWR_MGMT0_GYRO_MODE_OFF);
+		} else {
+			LOG_ERR("Wrong config with gyro mode");
 		}
 	} else if (attr == SENSOR_ATTR_FULL_SCALE) {
 		icm566xx_set_gyro_fsr(&drv_data->driver, val->val1);
@@ -282,7 +300,10 @@ static int icm566xx_attr_set(const struct device *dev, enum sensor_channel chan,
 				icm566xx_apex_enable(&drv_data->driver);
 				icm566xx_apex_enable_smd(&drv_data->driver);
 			} else if (val->val1 == TDK_APEX_WOM) {
-				icm566xx_apex_enable_wom(&drv_data->driver);
+				LOG_ERR("Not supported ATTR");
+			} else if (val->val1 == TDK_APEX_TAP) {
+				icm566xx_apex_enable(&drv_data->driver);
+				icm566xx_apex_enable_tap(&drv_data->driver);
 			} else if (val->val1 == TDK_APEX_DISABLE) {
 				icm566xx_edmp_disable_pedometer(&drv_data->driver);
 				icm566xx_edmp_disable_tilt(&drv_data->driver);
@@ -325,7 +346,6 @@ static int icm566xx_attr_get(const struct device *dev, enum sensor_channel chan,
 		}
 		break;
 	default:
-		LOG_ERR("Unsupported channel");
 		res = -EINVAL;
 		break;
 	}
@@ -341,6 +361,11 @@ static int icm566xx_channel_get(const struct device *dev, enum sensor_channel ch
 	const struct icm566xx_config *cfg = dev->config;
 #endif
 	bool is_high_res = false;
+
+	if ((chan >= SENSOR_CHAN_AMBIENT_TEMP && chan <= SENSOR_CHAN_ALL) ||
+		(chan >= SENSOR_CHAN_MAGN_X && chan <= SENSOR_CHAN_MAGN_XYZ)) {
+		return -ENOTSUP;
+	}
 
 #if INV_IMU_20BIT_REG_DATA_SUPPORTED
 	is_high_res = true;
@@ -402,8 +427,12 @@ static int icm566xx_channel_get(const struct device *dev, enum sensor_channel ch
 			val[0].val1 = (data->apex_status & ICM566XX_APEX_STATUS_MASK_WOM_X) ? 1 : 0;
 			val[1].val1 = (data->apex_status & ICM566XX_APEX_STATUS_MASK_WOM_Y) ? 1 : 0;
 			val[2].val1 = (data->apex_status & ICM566XX_APEX_STATUS_MASK_WOM_Z) ? 1 : 0;
-		} else if ((cfg->apex == TDK_APEX_TILT) || (cfg->apex == TDK_APEX_SMD)) {
+		} else if ((cfg->apex == TDK_APEX_TILT) ||
+					(cfg->apex == TDK_APEX_SMD) ||
+					(cfg->apex == TDK_APEX_TAP)) {
 			val[0].val1 = data->apex_status;
+		} else {
+			LOG_ERR("Unsupported apex feature");
 		}
 #endif
 		break;
@@ -549,10 +578,10 @@ static int icm566xx_init(const struct device *dev)
 	int err;
 
 	/* Initialize serial interface and device */
-	g_icm566xx_dev = dev;
+	data->driver.transport.context = (struct device *)dev;
 	data->driver.transport.read_reg = inv_io_hal_read_reg;
 	data->driver.transport.write_reg = inv_io_hal_write_reg;
-	data->driver.transport.sleep_us = inv_sleep_us;
+	data->driver.transport.sleep_us = icm566xx_inv_sleep_us;
 
 	switch (data->bus.rtio.type) {
 	case ICM566XX_BUS_SPI:
@@ -587,7 +616,7 @@ static int icm566xx_init(const struct device *dev)
 		drive_config0.pads_spi_slew = DRIVE_CONFIG0_PADS_SPI_SLEW_TYP_10NS;
 		err = icm566xx_write_reg(&data->driver, DRIVE_CONFIG0, 1,
 								(uint8_t *)&drive_config0);
-		inv_sleep_us(2); /* Takes effect 1.5 us after the register is programmed */
+		icm566xx_inv_sleep_us(2); /* Takes effect 1.5 us after the register is programmed */
 	}
 
 	/** Soft-reset sensor to restore config to defaults,
@@ -677,6 +706,11 @@ static int icm566xx_init(const struct device *dev)
 			LOG_ERR("Failed to initialize streaming: %d", err);
 			return err;
 		}
+	} else {
+		/*
+		 * Compliant with MISRA C - No trigger or stream mode enabled,
+		 * intentional fall-through
+		 */
 	}
 
 #ifdef CONFIG_TDK_APEX
@@ -687,9 +721,9 @@ static int icm566xx_init(const struct device *dev)
 		LOG_ERR("APEX Disable failed");
 		return err;
 	}
-#endif
 
 	k_sleep(K_MSEC(100));
+#endif
 
 	inv_imu_int_state_t int_config;
 
@@ -705,6 +739,7 @@ static int icm566xx_init(const struct device *dev)
 		return err;
 	}
 #endif
+
 	LOG_DBG("Init OK");
 
 	return 0;

--- a/drivers/sensor/tdk/icm566xx/icm566xx.h
+++ b/drivers/sensor/tdk/icm566xx/icm566xx.h
@@ -20,10 +20,10 @@
 #endif
 
 #include "icm566xx_bus.h"
-#include "imu/inv_imu_driver.h"
+#include <imu/inv_imu_driver.h>
 
 #ifdef CONFIG_TDK_APEX
-#include "imu/inv_imu_edmp.h"
+#include <imu/inv_imu_edmp.h>
 #endif
 
 /* Address value has a read bit */
@@ -220,6 +220,11 @@ int icm566xx_apex_enable_pedometer(const struct device *dev, inv_imu_device_t *s
 int icm566xx_apex_enable_tilt(inv_imu_device_t *s);
 int icm566xx_apex_enable_smd(inv_imu_device_t *s);
 int icm566xx_apex_enable_wom(inv_imu_device_t *s);
+int icm566xx_apex_enable_tap(inv_imu_device_t *s);
+int icm566xx_edmp_disable_pedometer(inv_imu_device_t *s);
+int icm566xx_edmp_disable_tilt(inv_imu_device_t *s);
+int icm566xx_edmp_disable_tap(inv_imu_device_t *s);
+int icm566xx_adv_disable_wom(inv_imu_device_t *s);
 #endif
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_ICM566XX_H_ */

--- a/drivers/sensor/tdk/icm566xx/icm566xx_apex.c
+++ b/drivers/sensor/tdk/icm566xx/icm566xx_apex.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "icm566xx.h"
-#include "icm566xx_h/imu/inv_imu.h"
 #include "imu/inv_imu_driver.h"
 #include "imu/inv_imu_edmp.h"
 #include "imu/inv_imu_driver_advanced.h"
@@ -13,6 +12,12 @@
 #elif defined(CONFIG_DT_HAS_INVENSENSE_ICM56686_ENABLED)
 #include "imu/inv_imu_edmp_apex.h"
 #endif
+#include <zephyr/logging/log.h>
+
+#define WOM_THRESHOLD_INITIAL_MG 200
+#define WOM_THRESHOLD_LOW_MG 24
+
+LOG_MODULE_REGISTER(ICM566XX_APEX, CONFIG_SENSOR_LOG_LEVEL);
 
 int icm566xx_apex_enable(inv_imu_device_t *s)
 {
@@ -20,8 +25,10 @@ int icm566xx_apex_enable(inv_imu_device_t *s)
 	inv_imu_int_state_t int_config;
 #if defined(CONFIG_DT_HAS_INVENSENSE_ICM56686_ENABLED)
 	inv_imu_edmp_apex_parameters_t apex_parameters;
-#endif
 	inv_imu_edmp_int_state_t apex_int_config;
+#endif
+
+	rc |= icm566xx_edmp_init_apex(s);
 
 	rc |= icm566xx_get_config_int(s, INV_IMU_INT1, &int_config);
 	int_config.INV_FIFO_THS = INV_IMU_DISABLE;
@@ -51,9 +58,12 @@ int icm566xx_apex_enable(inv_imu_device_t *s)
 	rc |= icm566xx_edmp_disable_tap(s);
 	rc |= icm566xx_edmp_disable(s);
 
+	/* Request DMP to re-initialize APEX */
+	rc |= icm566xx_edmp_recompute_apex_decimation(s);
+
 	/* Configure APEX parameters */
 	rc |= icm566xx_edmp_get_apex_parameters(s, &apex_parameters);
-	apex_parameters.power_save_en = INV_IMU_DISABLE;
+	apex_parameters.power_save.power_save_en = INV_IMU_DISABLE;
 	rc |= icm566xx_adv_disable_wom(s);
 	rc |= icm566xx_edmp_set_apex_parameters(s, &apex_parameters);
 
@@ -78,7 +88,6 @@ int icm566xx_apex_fetch_from_dmp(const struct device *dev)
 	struct icm566xx_data *data = dev->data;
 	int rc = 0;
 	inv_imu_int_state_t int_state;
-	inv_imu_edmp_int_state_t apex_state = {0};
 
 	/* Read APEX interrupt status */
 	rc |= icm566xx_get_int_status(&data->driver, INV_IMU_INT1, &int_state);
@@ -87,6 +96,8 @@ int icm566xx_apex_fetch_from_dmp(const struct device *dev)
 	if (int_state.INV_EDMP_EVENT) {
 #if defined(CONFIG_DT_HAS_INVENSENSE_ICM56686_ENABLED)
 		uint8_t step_cnt_ovflw = 0;
+		inv_imu_edmp_int_state_t apex_state = {0};
+
 		/* Read APEX interrupt status */
 		rc |= icm566xx_edmp_get_int_apex_status(&data->driver, &apex_state);
 
@@ -122,11 +133,7 @@ int icm566xx_apex_fetch_from_dmp(const struct device *dev)
 			inv_imu_edmp_tap_data_t tap_data;
 
 			icm566xx_edmp_get_tap_data(&data->driver, &tap_data);
-			if (tap_data.double_tap_timing == 0) {
-				data->apex_status = ICM566XX_APEX_STATUS_MASK_TAP;
-			} else {
-				data->apex_status = ICM566XX_APEX_STATUS_MASK_DOUBLE_TAP;
-			}
+			data->apex_status = tap_data.num;
 		}
 #endif
 	}
@@ -159,11 +166,19 @@ int icm566xx_apex_enable_pedometer(const struct device *dev, inv_imu_device_t *s
 	apex_int_config.INV_STEP_CNT_OVFL = INV_IMU_ENABLE;
 	apex_int_config.INV_STEP_DET = INV_IMU_ENABLE;
 	/* Apply interrupt configuration */
-	rc |= icm566xx_edmp_set_config_int_apex(s, &apex_int_config);
-	rc |= icm566xx_edmp_enable_pedometer(s);
+	rc = icm566xx_edmp_set_config_int_apex(s, &apex_int_config);
+	if (rc < 0) {
+		return -EIO;
+	}
+
+	rc = icm566xx_edmp_enable_pedometer(s);
+	if (rc < 0) {
+		return -EIO;
+	}
+
 	/* Enable EDMP if at least one feature is enabled */
-	rc |= icm566xx_edmp_enable(s);
-	return rc;
+	rc = icm566xx_edmp_enable(s);
+	return 0;
 }
 
 int icm566xx_apex_enable_tilt(inv_imu_device_t *s)
@@ -174,11 +189,23 @@ int icm566xx_apex_enable_tilt(inv_imu_device_t *s)
 	rc = icm566xx_edmp_get_config_int_apex(s, &apex_int_config);
 	apex_int_config.INV_TILT_DET = INV_IMU_ENABLE;
 	/* Apply interrupt configuration */
-	rc |= icm566xx_edmp_set_config_int_apex(s, &apex_int_config);
-	rc |= icm566xx_edmp_enable_tilt(s);
+	rc = icm566xx_edmp_set_config_int_apex(s, &apex_int_config);
+	if (rc < 0) {
+		return -EIO;
+	}
+
+	rc = icm566xx_edmp_enable_tilt(s);
+	if (rc < 0) {
+		return -EIO;
+	}
+
 	/* Enable EDMP if at least one feature is enabled */
-	rc |= icm566xx_edmp_enable(s);
-	return rc;
+	rc = icm566xx_edmp_enable(s);
+	if (rc < 0) {
+		return -EIO;
+	}
+
+	return 0;
 }
 
 int icm566xx_apex_enable_smd(inv_imu_device_t *s)
@@ -189,39 +216,97 @@ int icm566xx_apex_enable_smd(inv_imu_device_t *s)
 	rc = icm566xx_edmp_get_config_int_apex(s, &apex_int_config);
 	apex_int_config.INV_SMD = INV_IMU_ENABLE;
 	/* Apply interrupt configuration */
-	rc |= icm566xx_edmp_set_config_int_apex(s, &apex_int_config);
-	rc |= icm566xx_edmp_enable_smd(s);
-	/* Enable EDMP if at least one feature is enabled */
-	rc |= icm566xx_edmp_enable(s);
+	rc = icm566xx_edmp_set_config_int_apex(s, &apex_int_config);
+	if (rc < 0) {
+		return -EIO;
+	}
 
-	return rc;
+	rc = icm566xx_edmp_enable_smd(s);
+	if (rc < 0) {
+		return -EIO;
+	}
+
+	/* Enable EDMP if at least one feature is enabled */
+	rc = icm566xx_edmp_enable(s);
+	if (rc < 0) {
+		return -EIO;
+	}
+
+	return 0;
 }
 
 int icm566xx_apex_enable_wom(inv_imu_device_t *s)
 {
 	int rc = 0;
+	inv_imu_int_state_t int_config;
+	int wom_high_thr_en = 1; /* Indicates WOM state */
 
-	rc |= icm566xx_adv_configure_wom(s, DEFAULT_WOM_THS_MG, DEFAULT_WOM_THS_MG,
-					DEFAULT_WOM_THS_MG, TMST_WOM_CONFIG_WOM_INT_MODE_ANDED,
+	/* WOM threshold to be applied to IMU, ranges from 1 to 255, in 4mg unit */
+	uint8_t wom_threshold_high = WOM_THRESHOLD_INITIAL_MG / 4;
+	uint8_t wom_threshold_low = WOM_THRESHOLD_LOW_MG / 4;
+
+	/* Interrupts configuration: Enable only WOM interrupts */
+	memset(&int_config, INV_IMU_DISABLE, sizeof(int_config));
+	int_config.INV_WOM_X = INV_IMU_ENABLE;
+	int_config.INV_WOM_Y = INV_IMU_ENABLE;
+	int_config.INV_WOM_Z = INV_IMU_ENABLE;
+	rc |= icm566xx_set_config_int(s, INV_IMU_INT1, &int_config);
+
+	/* Configure WOM to produce signal when at least one axis exceed wom_threshold_high/low */
+	rc |= icm566xx_adv_configure_wom(s,
+					wom_high_thr_en ? wom_threshold_high : wom_threshold_low,
+					wom_high_thr_en ? wom_threshold_high : wom_threshold_low,
+					wom_high_thr_en ? wom_threshold_high : wom_threshold_low,
+					TMST_WOM_CONFIG_WOM_INT_MODE_ORED,
 					TMST_WOM_CONFIG_WOM_INT_DUR_1_SMPL);
 	rc |= icm566xx_adv_enable_wom(s);
+	rc |= icm566xx_set_accel_frequency(s, ACCEL_CONFIG0_ACCEL_ODR_12_5_HZ);
+	/* Select WUOSC clock to have accel in ULP (lowest power mode) */
+	rc |= icm566xx_select_accel_lp_clk(s, PWR_MGMT_0_ACCEL_LP_CLK_WUOSC);
+	/* Set 1x averaging, in order to minimize power consumption */
+	rc |= icm566xx_set_accel_lp_avg(s, IPREG_SYS2_REG_110_ACCEL_LP_AVG_1);
+	rc |= icm566xx_adv_enable_accel_lp(s);
 
-	return rc;
+	if (rc < 0) {
+		return -EIO;
+	}
+
+	return 0;
 }
 
 int icm566xx_apex_enable_tap(inv_imu_device_t *s)
 {
 	int rc = 0;
 	inv_imu_edmp_int_state_t apex_int_config;
+	inv_imu_edmp_apex_parameters_t apex_parameters;
 
-	rc = icm566xx_edmp_get_config_int_apex(s, &apex_int_config);
+	rc = icm566xx_set_accel_mode(s, PWR_MGMT0_ACCEL_MODE_LN);
+	rc |= icm566xx_edmp_set_frequency(s, DMP_EXT_SEN_ODR_CFG_APEX_ODR_800_HZ);
+	rc |= icm566xx_set_accel_frequency(s, ACCEL_CONFIG0_ACCEL_ODR_800_HZ);
+
+	rc |= icm566xx_edmp_get_apex_parameters(s, &apex_parameters);
+	apex_parameters.tap.tap_tmax			 = 800;
+	apex_parameters.tap.tap_tmin			 = 100;
+	apex_parameters.tap.tap_max_tap = 3;
+	apex_parameters.tap.tap_min_tap = 1;
+	apex_parameters.tap.tap_axis_select_mask = 63;
+	apex_parameters.tap.tap_max_energy_primary = 0;
+	apex_parameters.tap.tap_max_energy_secondary = 0;
+	rc |= icm566xx_edmp_set_apex_parameters(s, &apex_parameters);
+
+	rc |= icm566xx_edmp_get_config_int_apex(s, &apex_int_config);
 	apex_int_config.INV_TAP = INV_IMU_ENABLE;
 	/* Apply interrupt configuration */
 	rc |= icm566xx_edmp_set_config_int_apex(s, &apex_int_config);
 	rc |= icm566xx_edmp_enable_tap(s);
 	/* Enable EDMP if at least one feature is enabled */
 	rc |= icm566xx_edmp_enable(s);
-	return rc;
+
+	if (rc < 0) {
+		return -EIO;
+	}
+
+	return 0;
 }
 
 #endif

--- a/drivers/sensor/tdk/icm566xx/icm566xx_decoder.c
+++ b/drivers/sensor/tdk/icm566xx/icm566xx_decoder.c
@@ -17,9 +17,9 @@ LOG_MODULE_REGISTER(ICM566XX_DECODER, CONFIG_SENSOR_LOG_LEVEL);
 
 #define DT_DRV_COMPAT invensense_icm566xx
 
+#if defined(CONFIG_DT_HAS_INVENSENSE_ICM56686_ENABLED)
 static int32_t get_raw_reading_by_position(struct icm566xx_encoded_data *edata, int pos)
 {
-#if defined(CONFIG_DT_HAS_INVENSENSE_ICM56686_ENABLED)
 	int32_t high_16 = (int32_t)edata->payload.readings[pos];
 	int32_t low_4 = 0;
 
@@ -27,6 +27,8 @@ static int32_t get_raw_reading_by_position(struct icm566xx_encoded_data *edata, 
 		low_4 = edata->payload.ext_data[pos] & 0x0F;
 	} else if (pos >= 3 && pos <= 5) {
 		low_4 = edata->payload.ext_data[pos - 3] >> 4;
+	} else {
+		return -EINVAL;
 	}
 
 	int32_t raw_val = (high_16 << 4) | low_4;
@@ -36,11 +38,8 @@ static int32_t get_raw_reading_by_position(struct icm566xx_encoded_data *edata, 
 	}
 
 	return raw_val;
-#else
-	uint8_t *high_ptr = &edata->payload.buf[pos * 2];
-	return (int16_t)((high_ptr[0] << 8) | high_ptr[1]);
-#endif
 }
+#endif
 
 static int icm566xx_get_shift(enum sensor_channel channel, int accel_fs, int gyro_fs, int8_t *shift)
 {
@@ -168,6 +167,7 @@ int icm566xx_convert_raw_to_q31(struct icm566xx_encoded_data *edata, enum sensor
 	} else {
 		int64_t w_q31 = ((int64_t)whole * ((int64_t)INT32_MAX + 1)) >> shift;
 		int64_t f_q31 = ((int64_t)fraction * ((int64_t)INT32_MAX + 1)) / INT64_C(1000000);
+
 		f_q31 = f_q31 >> shift;
 		intermediate = w_q31 + f_q31;
 	}
@@ -379,6 +379,7 @@ static int icm566xx_one_shot_decode(const uint8_t *buffer, struct sensor_chan_sp
 		int32_t raw_reading;
 #if defined(CONFIG_DT_HAS_INVENSENSE_ICM56686_ENABLED)
 		int pos = icm566xx_get_channel_position(chan_spec.chan_type);
+
 		raw_reading = get_raw_reading_by_position(edata, pos);
 #else
 		raw_reading =

--- a/drivers/sensor/tdk/icm566xx/icm566xx_trigger.c
+++ b/drivers/sensor/tdk/icm566xx/icm566xx_trigger.c
@@ -127,10 +127,14 @@ int icm566xx_trigger_init(const struct device *dev)
 	err = k_sem_init(&data->triggers.sem, 0, 1);
 	__ASSERT_NO_MSG(!err);
 
-	(void)k_thread_create(&data->triggers.thread, data->triggers.thread_stack,
+	k_tid_t tid = k_thread_create(&data->triggers.thread, data->triggers.thread_stack,
 			      K_KERNEL_STACK_SIZEOF(data->triggers.thread_stack), icm566xx_thread,
 			      data, NULL, NULL, K_PRIO_COOP(CONFIG_ICM566XX_THREAD_PRIORITY), 0,
 			      K_NO_WAIT);
+
+#ifdef CONFIG_THREAD_NAME
+	k_thread_name_set(tid, "icm566xx_thread");
+#endif
 
 #elif defined(CONFIG_ICM566XX_TRIGGER_GLOBAL_THREAD)
 	k_work_init(&data->triggers.work, icm566xx_work_handler);

--- a/dts/bindings/sensor/invensense,icm56622-i2c.yaml
+++ b/dts/bindings/sensor/invensense,icm56622-i2c.yaml
@@ -2,35 +2,41 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    ICM56622 High-precision 6-axis motion tracking device
+    ICM56622 High-precision 6-axis motion tracking device.
     When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
-    gyro-odr properties in a .dts or .dtsi file you may include icm566xx.h
+    gyro-odr properties in devicetree, you may include icm566xx.h
     and use the macros defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/icm56622.h>
+    Example usage:
+        #include <zephyr/dt-bindings/sensor/icm566xx.h>
 
-    &i2c0 {
-      ...
+        &arduino_i2c {
+            status = "okay";
+            clock-frequency = <400000>;
 
-      icm56622: icm56622@68 {
-        ...
+            icm56622: icm56622@68 {
+                    compatible = "invensense,icm56622";
+                    reg = <0x68>;
+                    int-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;
 
-        accel-pwr-mode = <ICM566XX_DT_ACCEL_LN>;
-        accel-fs = <ICM566XX_DT_ACCEL_FS_16>;
-        accel-odr = <ICM566XX_DT_ACCEL_ODR_800>;
-        gyro-pwr-mode= <ICM566XX_DT_GYRO_LN>;
-        gyro-fs = <ICM566XX_DT_GYRO_FS_2000>;
-        gyro-odr = <ICM566XX_DT_GYRO_ODR_800>;
-      };
-    };
+                    accel-fs = <1>;
+                    accel-odr = <13>;
+                    accel-lpf = <1>;
+                    accel-pwr-mode = <2>;
+
+                    gyro-fs = <1>;
+                    gyro-odr = <13>;
+                    gyro-lpf = <1>;
+                    gyro-pwr-mode = <2>;
+            };
+        };
 
 compatible: "invensense,icm56622"
 
 properties:
   accel-fs:
     type: int
-    default: 0
+    default: 1
     description: |
       Specify the accelerometer range in g.
       Default is power-up configuration.
@@ -42,7 +48,7 @@ properties:
 
   gyro-fs:
     type: int
-    default: 0
+    default: 1
     description: |
       Specify the gyro range in degrees per second.
       Default is power-up configuration.
@@ -55,5 +61,12 @@ properties:
       - 6 # ICM566XX_DT_GYRO_FS_62_5
       - 7 # ICM566XX_DT_GYRO_FS_31_25
       - 8 # ICM566XX_DT_GYRO_FS_15_625
+
+  apex:
+    type: string
+    default: none
+    enum:
+      - none
+    description: APEX features.
 
 include: ["i2c-device.yaml", "invensense,icm566xx-common.yaml"]

--- a/dts/bindings/sensor/invensense,icm56622-i3c.yaml
+++ b/dts/bindings/sensor/invensense,icm56622-i3c.yaml
@@ -2,35 +2,42 @@
 # # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    ICM56622 High-precision 6-axis motion tracking device
+    ICM56622 High-precision 6-axis motion tracking device.
     When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
-    gyro-odr properties in a .dts or .dtsi file you may include icm566xx.h
+    gyro-odr properties in devicetree, you may include icm566xx.h
     and use the macros defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/icm566xx.h>
+    Example usage:
+        #include <zephyr/dt-bindings/sensor/icm566xx.h>
 
-    &i3c1 {
-      ...
+        &arduino_i3c {
+            status = "okay";
+            clock-frequency = <400000>;
 
-      icm56622: icm56622@680000046a00000011 {
-        ...
+            icm56622: icm56622@680000046a00000011 {
+                    compatible = "invensense,icm56622";
+                    reg = <0x68 0x0 0x0>;
+                    assigned-address = <0x6a>;
+                    int-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;
 
-        accel-pwr-mode = <ICM566XX_DT_ACCEL_LN>;
-        accel-fs = <ICM566XX_DT_ACCEL_FS_16>;
-        accel-odr = <ICM566XX_DT_ACCEL_ODR_800>;
-        gyro-pwr-mode= <ICM566XX_DT_GYRO_LN>;
-        gyro-fs = <ICM566XX_DT_GYRO_FS_2000>;
-        gyro-odr = <ICM566XX_DT_GYRO_ODR_800>;
-      };
-    };
+                    accel-fs = <1>;
+                    accel-odr = <13>;
+                    accel-lpf = <1>;
+                    accel-pwr-mode = <2>;
+
+                    gyro-fs = <1>;
+                    gyro-odr = <13>;
+                    gyro-lpf = <1>;
+                    gyro-pwr-mode = <2>;
+            };
+        };
 
 compatible: "invensense,icm56622"
 
 properties:
   accel-fs:
     type: int
-    default: 0
+    default: 1
     description: |
       Specify the accelerometer range in g.
       Default is power-up configuration.
@@ -42,7 +49,7 @@ properties:
 
   gyro-fs:
     type: int
-    default: 0
+    default: 1
     description: |
       Specify the gyro range in degrees per second.
       Default is power-up configuration.
@@ -55,5 +62,12 @@ properties:
       - 6 # ICM566XX_DT_GYRO_FS_62_5
       - 7 # ICM566XX_DT_GYRO_FS_31_25
       - 8 # ICM566XX_DT_GYRO_FS_15_625
+
+  apex:
+    type: string
+    default: none
+    enum:
+      - none
+    description: APEX features.
 
 include: ["i3c-device.yaml", "invensense,icm566xx-common.yaml"]

--- a/dts/bindings/sensor/invensense,icm56622-spi.yaml
+++ b/dts/bindings/sensor/invensense,icm56622-spi.yaml
@@ -2,35 +2,42 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    ICM56622 High-precision 6-axis motion tracking device
+    ICM56622 High-precision 6-axis motion tracking device.
     When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
-    gyro-odr properties in a .dts or .dtsi file you may include icm56622.h
+    gyro-odr properties in devicetree, you may include icm566xx.h
     and use the macros defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/icm566xx.h>
+    Example usage:
+        #include <zephyr/dt-bindings/sensor/icm566xx.h>
 
-    &spi0 {
-      ...
+        &arduino_spi {
+            status = "okay";
+            cs-gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
 
-      icm56622: icm56622@0 {
-        ...
+            icm56622: icm56622@0 {
+                    compatible = "invensense,icm56622";
+                    reg = <0>;
+                    spi-max-frequency = <1000000>;
+                    int-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;
 
-        accel-pwr-mode = <ICM566XX_DT_ACCEL_LN>;
-        accel-fs = <ICM566XX_DT_ACCEL_FS_16>;
-        accel-odr = <ICM566XX_DT_ACCEL_ODR_800>;
-        gyro-pwr-mode= <ICM566XX_DT_GYRO_LN>;
-        gyro-fs = <ICM566XX_DT_GYRO_FS_2000>;
-        gyro-odr = <ICM566XX_DT_GYRO_ODR_800>;
-      };
-    };
+                    accel-fs = <1>;
+                    accel-odr = <13>;
+                    accel-lpf = <1>;
+                    accel-pwr-mode = <2>;
+
+                    gyro-fs = <1>;
+                    gyro-odr = <13>;
+                    gyro-lpf = <1>;
+                    gyro-pwr-mode = <2>;
+            };
+        };
 
 compatible: "invensense,icm56622"
 
 properties:
   accel-fs:
     type: int
-    default: 0
+    default: 1
     description: |
       Specify the accelerometer range in g.
       Default is power-up configuration.
@@ -42,7 +49,7 @@ properties:
 
   gyro-fs:
     type: int
-    default: 0
+    default: 1
     description: |
       Specify the gyro range in degrees per second.
       Default is power-up configuration.
@@ -55,5 +62,12 @@ properties:
       - 6 # ICM566XX_DT_GYRO_FS_62_5
       - 7 # ICM566XX_DT_GYRO_FS_31_25
       - 8 # ICM566XX_DT_GYRO_FS_15_625
+
+  apex:
+    type: string
+    default: none
+    enum:
+      - none
+    description: APEX features.
 
 include: ["spi-device.yaml", "invensense,icm566xx-common.yaml"]

--- a/dts/bindings/sensor/invensense,icm56686-i2c.yaml
+++ b/dts/bindings/sensor/invensense,icm56686-i2c.yaml
@@ -2,28 +2,34 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    ICM56686 High-precision 6-axis motion tracking device
+    ICM56686 High-precision 6-axis motion tracking device.
     When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
-    gyro-odr properties in a .dts or .dtsi file you may include icm566xx.h
+    gyro-odr properties in devicetree, you may include icm566xx.h
     and use the macros defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/icm56686.h>
+    Example usage:
+        #include <zephyr/dt-bindings/sensor/icm566xx.h>
 
-    &i2c0 {
-      ...
+        &arduino_i2c {
+            status = "okay";
+            clock-frequency = <400000>;
 
-      icm56686: icm56686@68 {
-        ...
+            icm56686: icm56686@68 {
+                    compatible = "invensense,icm56686";
+                    reg = <0x68>;
+                    int-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;
 
-        accel-pwr-mode = <ICM566XX_DT_ACCEL_LN>;
-        accel-fs = <ICM566XX_DT_ACCEL_FS_32>;
-        accel-odr = <ICM566XX_DT_ACCEL_ODR_800>;
-        gyro-pwr-mode= <ICM566XX_DT_GYRO_LN>;
-        gyro-fs = <ICM566XX_DT_GYRO_FS_4000>;
-        gyro-odr = <ICM566XX_DT_GYRO_ODR_800>;
-      };
-    };
+                    accel-fs = <0>;
+                    accel-odr = <13>;
+                    accel-lpf = <1>;
+                    accel-pwr-mode = <2>;
+
+                    gyro-fs = <0>;
+                    gyro-odr = <13>;
+                    gyro-lpf = <1>;
+                    gyro-pwr-mode = <2>;
+            };
+        };
 
 compatible: "invensense,icm56686"
 
@@ -57,5 +63,17 @@ properties:
       - 6 # ICM566XX_DT_GYRO_FS_62_5
       - 7 # ICM566XX_DT_GYRO_FS_31_25
       - 8 # ICM566XX_DT_GYRO_FS_15_625
+
+  apex:
+    type: string
+    default: none
+    enum:
+      - none
+      - pedometer
+      - tilt
+      - smd
+      - wom
+      - tap
+    description: APEX (Advanced Pedometer and Event Detection) features.
 
 include: ["i2c-device.yaml", "invensense,icm566xx-common.yaml"]

--- a/dts/bindings/sensor/invensense,icm56686-i3c.yaml
+++ b/dts/bindings/sensor/invensense,icm56686-i3c.yaml
@@ -2,28 +2,35 @@
 # # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    ICM56686 High-precision 6-axis motion tracking device
+    ICM56686 High-precision 6-axis motion tracking device.
     When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
-    gyro-odr properties in a .dts or .dtsi file you may include icm566xx.h
+    gyro-odr properties in devicetree, you may include icm566xx.h
     and use the macros defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/icm566xx.h>
+    Example usage:
+        #include <zephyr/dt-bindings/sensor/icm566xx.h>
 
-    &i3c1 {
-      ...
+        &arduino_i3c {
+            status = "okay";
+            clock-frequency = <400000>;
 
-      icm56686: icm56686@680000046a00000011 {
-        ...
+            icm56686: icm56686@680000046a00000011 {
+                    compatible = "invensense,icm56686";
+                    reg = <0x68 0x0 0x0>;
+                    assigned-address = <0x6a>;
+                    int-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;
 
-        accel-pwr-mode = <ICM566XX_DT_ACCEL_LN>;
-        accel-fs = <ICM566XX_DT_ACCEL_FS_32>;
-        accel-odr = <ICM566XX_DT_ACCEL_ODR_800>;
-        gyro-pwr-mode= <ICM566XX_DT_GYRO_LN>;
-        gyro-fs = <ICM566XX_DT_GYRO_FS_4000>;
-        gyro-odr = <ICM566XX_DT_GYRO_ODR_800>;
-      };
-    };
+                    accel-fs = <0>;
+                    accel-odr = <13>;
+                    accel-lpf = <1>;
+                    accel-pwr-mode = <2>;
+
+                    gyro-fs = <0>;
+                    gyro-odr = <13>;
+                    gyro-lpf = <1>;
+                    gyro-pwr-mode = <2>;
+            };
+        };
 
 compatible: "invensense,icm56686"
 
@@ -57,5 +64,17 @@ properties:
       - 6 # ICM566XX_DT_GYRO_FS_62_5
       - 7 # ICM566XX_DT_GYRO_FS_31_25
       - 8 # ICM566XX_DT_GYRO_FS_15_625
+
+  apex:
+    type: string
+    default: none
+    enum:
+      - none
+      - pedometer
+      - tilt
+      - smd
+      - wom
+      - tap
+    description: APEX (Advanced Pedometer and Event Detection) features.
 
 include: ["i3c-device.yaml", "invensense,icm566xx-common.yaml"]

--- a/dts/bindings/sensor/invensense,icm56686-spi.yaml
+++ b/dts/bindings/sensor/invensense,icm56686-spi.yaml
@@ -2,28 +2,35 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    ICM56686 High-precision 6-axis motion tracking device
+    ICM56686 High-precision 6-axis motion tracking device.
     When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
-    gyro-odr properties in a .dts or .dtsi file you may include icm56686.h
+    gyro-odr properties in devicetree, you may include icm566xx.h
     and use the macros defined there.
 
-    Example:
-    #include <zephyr/dt-bindings/sensor/icm566xx.h>
+    Example usage:
+        #include <zephyr/dt-bindings/sensor/icm566xx.h>
 
-    &spi0 {
-      ...
+        &arduino_spi {
+            status = "okay";
+            cs-gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
 
-      icm56686: icm56686@0 {
-        ...
+            icm56686: icm56686@0 {
+                    compatible = "invensense,icm56686";
+                    reg = <0>;
+                    spi-max-frequency = <1000000>;
+                    int-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;
 
-        accel-pwr-mode = <ICM566XX_DT_ACCEL_LN>;
-        accel-fs = <ICM566XX_DT_ACCEL_FS_32>;
-        accel-odr = <ICM566XX_DT_ACCEL_ODR_800>;
-        gyro-pwr-mode= <ICM566XX_DT_GYRO_LN>;
-        gyro-fs = <ICM566XX_DT_GYRO_FS_4000>;
-        gyro-odr = <ICM566XX_DT_GYRO_ODR_800>;
-      };
-    };
+                    accel-fs = <0>;
+                    accel-odr = <13>;
+                    accel-lpf = <1>;
+                    accel-pwr-mode = <2>;
+
+                    gyro-fs = <0>;
+                    gyro-odr = <13>;
+                    gyro-lpf = <1>;
+                    gyro-pwr-mode = <2>;
+            };
+        };
 
 compatible: "invensense,icm56686"
 
@@ -57,5 +64,17 @@ properties:
       - 6 # ICM566XX_DT_GYRO_FS_62_5
       - 7 # ICM566XX_DT_GYRO_FS_31_25
       - 8 # ICM566XX_DT_GYRO_FS_15_625
+
+  apex:
+    type: string
+    default: none
+    enum:
+      - none
+      - pedometer
+      - tilt
+      - smd
+      - wom
+      - tap
+    description: APEX (Advanced Pedometer and Event Detection) features.
 
 include: ["spi-device.yaml", "invensense,icm566xx-common.yaml"]

--- a/dts/bindings/sensor/invensense,icm566xx-common.yaml
+++ b/dts/bindings/sensor/invensense,icm566xx-common.yaml
@@ -113,10 +113,11 @@ properties:
   fifo-watermark:
     type: int
     default: 0
+#    min: 0
+#    max: 104
     description: |
       Specify the FIFO watermark level in frame count.
       Default is power-up configuration (disabled).
-      Valid range: 0 - 104
 
   fifo-watermark-equals:
     type: boolean
@@ -126,14 +127,3 @@ properties:
 
       Otherwise, it will generate interrupts when the level is greater or equals the FIFO Watermark
       Threshold (count >= watermark).
-
-  apex:
-    type: string
-    default: "none"
-    enum:
-      - "none"
-      - "pedometer"
-      - "tilt"
-      - "smd"
-      - "wom"
-    description: "APEX features selection"

--- a/include/zephyr/drivers/sensor/tdk_apex.h
+++ b/include/zephyr/drivers/sensor/tdk_apex.h
@@ -17,11 +17,21 @@
  * cannot be expressed within the sensor driver abstraction.
  */
 
-/** TDK APEX features */
+/** @name TDK APEX features */
+/** @{ */
+/** @brief Disable APEX feature. */
+#define TDK_APEX_DISABLE   (0)
+/** @brief Enable Pedometer feature. */
 #define TDK_APEX_PEDOMETER (1)
+/** @brief Enable Tilt detection feature. */
 #define TDK_APEX_TILT      (2)
+/** @brief Enable Significant Motion Detector (SMD) feature. */
 #define TDK_APEX_SMD       (3)
+/** @brief Enable Wake on Motion (WoM) feature. */
 #define TDK_APEX_WOM       (4)
+/** @brief Enable TAP gesture detection feature. */
+#define TDK_APEX_TAP       (5)
+/** @} */
 
 /**
  * @brief Extended sensor channel for TDK MEMS supportintg APEX features

--- a/samples/sensor/tdk_apex/src/main.c
+++ b/samples/sensor/tdk_apex/src/main.c
@@ -11,6 +11,13 @@
 #include <zephyr/drivers/sensor/tdk_apex.h>
 #include <stdio.h>
 
+/** @brief Tap number definition */
+typedef enum {
+	TAP_TRIPLE = 0x03,
+	TAP_DOUBLE = 0x02,
+	TAP_SINGLE = 0x01,
+} tap_num_t;
+
 static struct sensor_trigger data_trigger;
 
 /* Flag set from IMU device irq handler */
@@ -89,6 +96,8 @@ int main(void)
 		printf("WOM data sample.\n");
 	} else if (apex_mode.val1 == TDK_APEX_SMD) {
 		printf("SMD data sample.\n");
+	} else if (apex_mode.val1 == TDK_APEX_TAP) {
+		printf("TAP data sample.\n");
 	}
 	apex_mode.val2 = 0;
 	sensor_attr_set(dev, SENSOR_CHAN_APEX_MOTION, SENSOR_ATTR_CONFIGURATION, &apex_mode);
@@ -142,6 +151,20 @@ int main(void)
 
 				printf("[%s]: %s\n", now_str(),
 				       apex_smd.val1 ? "SMD" : "Unknown trig");
+			} else if (apex_mode.val1 == TDK_APEX_TAP) {
+				struct sensor_value apex_tap;
+
+				sensor_channel_get(dev, SENSOR_CHAN_APEX_MOTION, &apex_tap);
+
+				if (apex_tap.val1 == TAP_SINGLE) {
+					printf("[%s]: Single TAP\n", now_str());
+				} else if (apex_tap.val1 == TAP_DOUBLE) {
+					printf("[%s]: Double TAP\n", now_str());
+				} else if (apex_tap.val1 == TAP_TRIPLE) {
+					printf("[%s]: Triple TAP\n", now_str());
+				} else {
+					printf("[%s]: Unknown trig\n", now_str());
+				}
 			}
 			irq_from_device = 0;
 		}

--- a/west.yml
+++ b/west.yml
@@ -255,7 +255,7 @@ manifest:
       groups:
         - hal
     - name: hal_tdk
-      revision: 603b5456020718499f48f019324b47c05f5f6156
+      revision: 6a2669c3d82dc1a9f7e9ca4acc260f261688cfc0
       path: modules/hal/tdk
       groups:
         - hal


### PR DESCRIPTION
### Description

This PR introduces support and updates for the **TDK InvenSense ICM566xx series** (including ICM56622 and ICM56686) 6-axis motion sensors. 

It integrates the official TDK InvenSense hardware abstraction layer (HAL) into the `hal_tdk` module, implements the core sensor driver, defines the devicetree bindings, and provides a sample application showcasing the TAP APEX feature.

### Component Changes

- **modules/hal_tdk**: Added baseline support for the ICM566xx sensor series using the official TDK HAL.
- **samples/sensor**: Added a dedicated `tdk_apex` sample to demonstrate the TAP APEX feature.
- **drivers/sensor**: Implemented core driver logic for ICM566xx with support for multi-instance configurations and APEX features.
- **dts/bindings**: Added devicetree properties to support the APEX hardware features.